### PR TITLE
Retry messages when no subscriber present

### DIFF
--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterBuilder.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterBuilder.java
@@ -129,8 +129,8 @@ public class RedisClusterBuilder
         return this;
     }
 
-    public RedisClusterBuilder messageSendAttempts(final Integer resendAttempts) {
-        redisClusterConfig.setMessageSendAttempts(resendAttempts);
+    public RedisClusterBuilder messageSendAttempts(final Integer messageSendAttempts) {
+        redisClusterConfig.setMessageSendAttempts(messageSendAttempts);
         return this;
     }
 

--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterBuilder.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterBuilder.java
@@ -129,8 +129,8 @@ public class RedisClusterBuilder
         return this;
     }
 
-    public RedisClusterBuilder messageResendAttempts(final Integer resendAttempts) {
-        redisClusterConfig.setMessageResendAttempts(resendAttempts);
+    public RedisClusterBuilder messageSendAttempts(final Integer resendAttempts) {
+        redisClusterConfig.setMessageSendAttempts(resendAttempts);
         return this;
     }
 

--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterBuilder.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterBuilder.java
@@ -129,6 +129,11 @@ public class RedisClusterBuilder
         return this;
     }
 
+    public RedisClusterBuilder messageResendAttempts(final Integer resendAttempts) {
+        redisClusterConfig.setMessageResendAttempts(resendAttempts);
+        return this;
+    }
+
     public RedisClusterBuilder retryInterval(final Integer retryInterval) {
         redisClusterConfig.setRetryInterval(retryInterval);
         return this;

--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
@@ -55,6 +55,7 @@ public class RedisClusterConfig
     private Integer retryAttempts = 5;
     private Integer retryInterval = 1000;
     private Integer failedAttempts = Integer.MAX_VALUE;
+    private Integer messageResendAttempts = Integer.MAX_VALUE;
     private Boolean dnsMonitoring = true;
     private Integer dnsMonitoringInverval = 10000;
     private Integer messagingHealthcheckInterval = 10000;
@@ -309,5 +310,15 @@ public class RedisClusterConfig
     public void setMessagingHealthcheckInterval(Integer messagingHealthcheckInterval)
     {
         this.messagingHealthcheckInterval = messagingHealthcheckInterval;
+    }
+
+    public Integer getMessageResendAttempts()
+    {
+        return messageResendAttempts;
+    }
+
+    public void setMessageResendAttempts(Integer messageResendAttempts)
+    {
+        this.messageResendAttempts = messageResendAttempts;
     }
 }

--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
@@ -55,7 +55,7 @@ public class RedisClusterConfig
     private Integer retryAttempts = 5;
     private Integer retryInterval = 1000;
     private Integer failedAttempts = Integer.MAX_VALUE;
-    private Integer messageSendAttempts = Integer.MAX_VALUE;
+    private Integer messageSendAttempts = 1;
     private Boolean dnsMonitoring = true;
     private Integer dnsMonitoringInverval = 10000;
     private Integer messagingHealthcheckInterval = 10000;

--- a/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
+++ b/src/main/java/cloud/orbit/actors/cluster/RedisClusterConfig.java
@@ -55,7 +55,7 @@ public class RedisClusterConfig
     private Integer retryAttempts = 5;
     private Integer retryInterval = 1000;
     private Integer failedAttempts = Integer.MAX_VALUE;
-    private Integer messageResendAttempts = Integer.MAX_VALUE;
+    private Integer messageSendAttempts = Integer.MAX_VALUE;
     private Boolean dnsMonitoring = true;
     private Integer dnsMonitoringInverval = 10000;
     private Integer messagingHealthcheckInterval = 10000;
@@ -312,13 +312,13 @@ public class RedisClusterConfig
         this.messagingHealthcheckInterval = messagingHealthcheckInterval;
     }
 
-    public Integer getMessageResendAttempts()
+    public Integer getMessageSendAttempts()
     {
-        return messageResendAttempts;
+        return messageSendAttempts;
     }
 
-    public void setMessageResendAttempts(Integer messageResendAttempts)
+    public void setMessageSendAttempts(Integer messageSendAttempts)
     {
-        this.messageResendAttempts = messageResendAttempts;
+        this.messageSendAttempts = messageSendAttempts;
     }
 }

--- a/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
+++ b/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
@@ -154,18 +154,14 @@ public class RedisConnectionManager
                     .whenComplete((x, e) -> {
                        if(e != null) {
                            logger.error("Failed to send message to channel '{}'", channelId, e);
-                       } else {
-                           if(x == 0) {
-                               if(attempt >= redisClusterConfig.getMessageResendAttempts()) {
-                                   logger.error("Failed to send message to channel '{}' after {} attempts.", channelId, attempt);
-                               } else {
-                                   logger.warn("Failed to send message to channel '{}' on attempt {}. Retrying...", channelId, attempt);
-                                   sendMessageToChannel(channelId, msg, localMessagingClients, attempt + 1);
-                               }
+                       } else if(x == 0) {
+                           if(attempt >= redisClusterConfig.getMessageResendAttempts()) {
+                               logger.error("Failed to send message to channel '{}' after {} attempts.", channelId, attempt);
+                           } else {
+                               logger.warn("Failed to send message to channel '{}' on attempt {}. Retrying...", channelId, attempt);
+                               sendMessageToChannel(channelId, msg, localMessagingClients, attempt + 1);
                            }
                        }
-
-
                     });
         }
         else

--- a/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
+++ b/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
@@ -167,7 +167,6 @@ public class RedisConnectionManager
         else
         {
             logger.error("Failed to send message to channel '{}', no redis messaging instances were available after {} attempts.", channelId, attempt);
-            throw new UncheckedException("No Redis messaging instances available.");
         }
     }
 

--- a/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
+++ b/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
@@ -143,7 +143,7 @@ public class RedisConnectionManager
             sendMessageToChannel(channelId, msg, localMessagingClients, 0);
     }
 
-    private void sendMessageToChannel(final String channelId, final Object msg, List<RedisOrbitClient> localMessagingClients, final int attempt) {
+    private void sendMessageToChannel(final String channelId, final Object msg, final List<RedisOrbitClient> localMessagingClients, final int attempt) {
         final int activeClientCount = localMessagingClients.size();
         if(activeClientCount > 0)
         {
@@ -159,7 +159,7 @@ public class RedisConnectionManager
                                if(attempt >= redisClusterConfig.getMessageResendAttempts()) {
                                    logger.error("Failed to send message to channel '{}' after {} attempts.", channelId, attempt);
                                } else {
-                                   logger.warn("Failed to send message to channel '{}' on attempt {}. Retrying...");
+                                   logger.warn("Failed to send message to channel '{}' on attempt {}. Retrying...", channelId, attempt);
                                    sendMessageToChannel(channelId, msg, localMessagingClients, attempt + 1);
                                }
                            }

--- a/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
+++ b/src/main/java/cloud/orbit/actors/cluster/impl/RedisConnectionManager.java
@@ -149,6 +149,7 @@ public class RedisConnectionManager
         if (activeClientCount == 0)
         {
             logger.error("Failed to send message to channel '{}', no redis messaging instances were available after {} attempts.", channelId, attempt);
+            return;
         }
 
         final int randomId = ThreadLocalRandom.current().nextInt(activeClientCount);


### PR DESCRIPTION
Resolves #7. Warnings are now logged and reattempts are made until no messaging nodes are available to try or the retry attempt limit is hit.
This also allows zero downtime changes (if carefully planned) of Redis messaging nodes. 